### PR TITLE
pack-jack2.sh: add microphone permissions entry

### DIFF
--- a/pack-jack2.sh
+++ b/pack-jack2.sh
@@ -110,6 +110,7 @@ elif [ "${MACOS}" -eq 1 ]; then
     sed -i -e 's|com.yourcompany.qjackctl|org.rncbc.QjackCtl|' "${qjackctl_app}/Contents/Info.plist"
     sed -i -e 's|string>qjackctl</string>|string>QjackCtl</string>|' "${qjackctl_app}/Contents/Info.plist"
     sed -i -e 's|<string></string>|<string>QjackCtl.icns</string>|' "${qjackctl_app}/Contents/Info.plist"
+    sed -i -e '/\/dict/i\'$'\n''\'$'\t''\<key\>NSMicrophoneUsageDescription\<\/key\>\'$'\n''\'$'\t''\<string\>Jack wants to use your microphone or sound input\<\/string\>'$'\n'$'\n' "${qjackctl_app}/Contents/Info.plist"
     rm "${qjackctl_app}/Contents/Info.plist-e"
     mv "${qjackctl_app}/Contents/MacOS/qjackctl" "${qjackctl_app}/Contents/MacOS/QjackCtl" 
 


### PR DESCRIPTION
This is an attempt to add appropriate `Info.plist` entry to enable microphone permissions on macOS for QJackCtl. 
The added `sed` code was tested on the `Info.plist` from the shipped version of QJackCtl app bundle from jack 1.9.16 and results in the following contents:
<details>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>NSPrincipalClass</key>
	<string>NSApplication</string>
	<key>CFBundleIconFile</key>
	<string></string>
	<key>CFBundlePackageType</key>
	<string>APPL</string>
	<key>CFBundleGetInfoString</key>
	<string>Created by Qt/QMake</string>
	<key>CFBundleSignature</key>
	<string>????</string>
	<key>CFBundleExecutable</key>
	<string>qjackctl</string>
	<key>CFBundleIdentifier</key>
	<string>com.yourcompany.qjackctl</string>
	<key>NOTE</key>
	<string>This file was generated by Qt/QMake.</string>
	<key>NSMicrophoneUsageDescription</key>
	<string>Jack wants to use your microphone or sound input</string>
</dict>
</plist>

```
</details>

I didn't test this as part of the script in this repo, sorry...

Should fix https://github.com/jackaudio/jack2/issues/724