### PR TITLE
QJackCtl: include qwindowsvistastyle.dll in jack installer

### DIFF
--- a/pack-jack2.sh
+++ b/pack-jack2.sh
@@ -82,6 +82,7 @@ if [ "${WIN32}" -eq 1 ]; then
     echo "#define VERSION \"${JACK2_VERSION}\"" > "version.iss"
     ln -sf "${PAWPAW_PREFIX}/bin/Qt5"{Core,Gui,Network,Widgets,Xml}".dll" .
     ln -sf "${PAWPAW_PREFIX}/lib/qt5/plugins/platforms/qwindows.dll" .
+    ln -sf "${PAWPAW_PREFIX}/lib/qt5/plugins/styles/qwindowsvistastyle.dll" .
     ln -sf "${jack2_prefix}" "${PAWPAW_TARGET}"
     env WINEPREFIX="${innodir}" wine "${iscc}" "${PAWPAW_TARGET}.iss"
     popd


### PR DESCRIPTION
This DLL is required to have a proper Qt skin on Windows.

This PR requires https://github.com/jackaudio/jack2/pull/843 to really fix the issue.

I've tested it on CI: https://github.com/amurzeau/PawPaw/actions/runs/1758463520

Closes: #24 
