### PR TITLE
bootstrap-deps: Force remove cairo so it doesn't fail macos build

### DIFF
--- a/.github/workflows/bootstrap-deps.sh
+++ b/.github/workflows/bootstrap-deps.sh
@@ -74,7 +74,7 @@ function install_compiler() {
 case "${1}" in
     "macos"|"macos-intel"|"macos-10.15"|"macos-universal"|"macos-universal-10.15")
         brew install autoconf automake cmake coreutils gawk git gnu-sed jq libtool make meson
-        brew uninstall --ignore-dependencies cairo freetype
+        brew uninstall --ignore-dependencies -f cairo freetype
 
         [ -n "${GITHUB_ENV}" ] && echo "PAWPAW_PACK_NAME=${1}-$(sw_vers -productVersion | cut -d '.' -f 1)" >> "${GITHUB_ENV}"
     ;;


### PR DESCRIPTION
WIP: sending a pull request here so I can test the CI on this hash.  I tried making a fork but I was missing some resources to make dpf-makefile-action work for my fork.